### PR TITLE
fix(XpcConnect.cpp): Renaming all instances of XpcConnection to XpcConnect

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,11 +1,11 @@
 {
   'targets': [
     {
-      'target_name': 'xpc-connection',
+      'target_name': 'xpc-connect',
       'conditions': [
         ['OS=="mac"', {
           'sources': [
-            'src/XpcConnection.cpp'
+            'src/XpcConnect.cpp'
           ],
           # cflags on OS X are stupid and have to be defined like this
           'defines': [

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var events = require('events');
 
-var binding = require('bindings')('xpc-connection.node');
-var XpcConnection = binding.XpcConnection;
+var binding = require('bindings')('xpc-connect.node');
+var XpcConnect = binding.XpcConnect;
 
-inherits(XpcConnection, events.EventEmitter);
+inherits(XpcConnect, events.EventEmitter);
 
 // extend prototype
 function inherits(target, source) {
@@ -12,4 +12,4 @@ function inherits(target, source) {
   }
 }
 
-module.exports = XpcConnection;
+module.exports = XpcConnect;

--- a/src/XpcConnect.h
+++ b/src/XpcConnect.h
@@ -10,7 +10,7 @@
 #include <nan.h>
 
 
-class XpcConnection : public node::ObjectWrap {
+class XpcConnect : public node::ObjectWrap {
 
 public:
   static NAN_MODULE_INIT(Init);
@@ -21,8 +21,8 @@ public:
   static NAN_METHOD(SendMessage);
 
 private:
-  XpcConnection(std::string serviceName);
-  ~XpcConnection();
+  XpcConnect(std::string serviceName);
+  ~XpcConnect();
 
   static xpc_object_t ValueToXpcObject(v8::Local<v8::Value> object);
   static xpc_object_t ObjectToXpcObject(v8::Local<v8::Object> object);


### PR DESCRIPTION
By renaming all instances of XpcConnection to XpcConnect we will be able to discern more quickly if
bug reports are actually stemming from XpcConnect or the deprecated library