### PR TITLE
ci(.circleci/config.yml): wait for build job to finish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,5 @@ workflows:
     when:
       equal: [master, << pipeline.git.branch >>]
     jobs:
-      - deploy:
-          requires:
-            - os-tests
+      - deploy
           


### PR DESCRIPTION
the requires clause requires a job, not a workflow reference