### PR TITLE
fix(README.md): fix GitHub Action build badge redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # xpc-connect
 
-![GitHub Actions build status](https://github.com/jongear/xpc-connect/actions/workflows/main.yml/badge.svg) [![downloads](https://img.shields.io/npm/dt/xpc-connect.svg)](https://www.npmjs.com/package/xpc-connect) [![Contributor count](https://img.shields.io/github/contributors/jongear/xpc-connect.svg)](https://github.com/jongear/xpc-connect/graphs/contributors)
+[![GitHub Actions build status](https://github.com/jongear/xpc-connect/actions/workflows/main.yml/badge.svg)](https://github.com/jongear/xpc-connect/actions?query=branch:master) [![downloads](https://img.shields.io/npm/dt/xpc-connect.svg)](https://www.npmjs.com/package/xpc-connect) [![Contributor count](https://img.shields.io/github/contributors/jongear/xpc-connect.svg)](https://github.com/jongear/xpc-connect/graphs/contributors)
 
 [XPC Services connection](https://developer.apple.com/documentation/xpc/xpc_services_connection_h) bindings for node.js
 


### PR DESCRIPTION
The GH Action build badge was redirecting to the svg on click. This has been fixed to redirect to
the GH Action build page